### PR TITLE
GATs are stable

### DIFF
--- a/crates/ruma-macros/src/api/response.rs
+++ b/crates/ruma-macros/src/api/response.rs
@@ -267,13 +267,6 @@ impl TryFrom<Field> for ResponseField {
     type Error = syn::Error;
 
     fn try_from(mut field: Field) -> syn::Result<Self> {
-        if has_lifetime(&field.ty) {
-            return Err(syn::Error::new_spanned(
-                field.ident,
-                "Lifetimes on Response fields cannot be supported until GAT are stable",
-            ));
-        }
-
         let (mut api_attrs, attrs) =
             field.attrs.into_iter().partition::<Vec<_>, _>(|attr| attr.path().is_ident("ruma_api"));
         field.attrs = attrs;
@@ -305,6 +298,7 @@ impl ToTokens for ResponseField {
     }
 }
 
+#[allow(dead_code)]
 fn has_lifetime(ty: &Type) -> bool {
     struct Visitor {
         found_lifetime: bool,


### PR DESCRIPTION
<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->
