### PR TITLE
accountdata: add an enum to allow returning both global and room accountdata

### DIFF
--- a/crates/ruma-events/src/kinds.rs
+++ b/crates/ruma-events/src/kinds.rs
@@ -10,6 +10,8 @@ use ruma_macros::Event;
 use serde::{ser::SerializeStruct, Deserialize, Deserializer, Serialize};
 use serde_json::value::RawValue as RawJsonValue;
 
+use crate::{AnyGlobalAccountDataEvent, AnyRoomAccountDataEvent};
+
 use super::{
     AnyInitialStateEvent, EmptyStateKey, EphemeralRoomEventContent, EventContent,
     EventContentFromType, GlobalAccountDataEventContent, MessageLikeEventContent,
@@ -18,6 +20,26 @@ use super::{
     RedactionDeHelper, RoomAccountDataEventContent, StateEventType, StaticStateEventContent,
     ToDeviceEventContent,
 };
+
+/// Enum allowing to use the same structures for global and room account data
+#[derive(Debug)]
+#[allow(clippy::exhaustive_enums)]
+pub enum AnyAccountDataEvent {
+    /// An event for a specific room
+    Room(AnyRoomAccountDataEvent),
+    /// An event for the whole account
+    Global(AnyGlobalAccountDataEvent),
+}
+
+/// Enum allowing to use the same structures for global and room account data
+#[derive(Debug)]
+#[allow(clippy::exhaustive_enums)]
+pub enum AnyRawAccountDataEvent {
+    /// An event for a specific room
+    Room(Raw<AnyRoomAccountDataEvent>),
+    /// An event for the whole account
+    Global(Raw<AnyGlobalAccountDataEvent>),
+}
 
 /// A global account data event.
 #[derive(Clone, Debug, Event)]


### PR DESCRIPTION
<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->
