### PR TITLE
Reserve the correct amount of headers

### DIFF
--- a/crates/ruma-macros/src/api/request/outgoing.rs
+++ b/crates/ruma-macros/src/api/request/outgoing.rs
@@ -40,11 +40,14 @@ impl Request {
             quote! { "" }
         };
 
+        let mut additional_headers: usize = 0;
+
         // If there are no body fields, the request body will be empty (not `{}`), so the
         // `application/json` content-type would be wrong. It may also cause problems with CORS
         // policies that don't allow the `Content-Type` header (for things such as `.well-known`
         // that are commonly handled by something else than a homeserver).
         let mut header_kvs = if self.raw_body_field().is_some() || self.has_body_fields() {
+            additional_headers += 1;
             quote! {
                 req_headers.insert(
                     #http::header::CONTENT_TYPE,
@@ -80,6 +83,7 @@ impl Request {
             }
         }));
 
+        additional_headers += 1;
         header_kvs.extend(quote! {
             req_headers.extend(METADATA.authorization_header(access_token)?);
         });
@@ -99,7 +103,8 @@ impl Request {
 
         let (impl_generics, ty_generics, where_clause) = self.generics.split_for_impl();
 
-        let reserve_headers = 1 + self.header_fields().count();
+        let reserve_headers = self.header_fields().count() + additional_headers;
+
         quote! {
             #[automatically_derived]
             #[cfg(feature = "client")]


### PR DESCRIPTION
<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->

This was causing an issue in debug mode when pinging appservices. It will now correctly count additional headers from content-type and auth rather than a hardcoded 1 additional reserved header.