### PR TITLE
derive PartialEq for CrossSigningKey and identifiers::Signatures 

### DIFF
--- a/crates/ruma-client-api/src/keys/upload_signing_keys.rs
+++ b/crates/ruma-client-api/src/keys/upload_signing_keys.rs
@@ -26,27 +26,13 @@ pub mod v3 {
             1.1 => "/_matrix/client/v3/keys/device_signing/upload",
         }
     };
-
-    fn or_empty<'de, D: serde::Deserializer<'de>, T: serde::Deserialize<'de>>(
-        deserializer: D,
-    ) -> Result<Option<T>, D::Error> {
-        #[derive(serde::Deserialize)]
-        #[serde(untagged)]
-        enum OrEmpty<T> {
-            NotEmpty(T),
-            Empty {},
-        }
-        let res = <Option<OrEmpty<T>> as serde::Deserialize<'de>>::deserialize(deserializer)?;
-        Ok(res.and_then(|res| if let OrEmpty::NotEmpty(a) = res { Some(a) } else { None }))
-    }
-
     /// Request type for the `upload_signing_keys` endpoint.
     #[request(error = UiaaResponse)]
     #[derive(Default)]
     pub struct Request {
         /// Additional authentication information for the user-interactive authentication API.
         #[serde(skip_serializing_if = "Option::is_none")]
-        #[serde(deserialize_with = "or_empty")]
+        #[serde(deserialize_with = "ruma_common::serde::or_empty")]
         #[serde(default)]
         pub auth: Option<AuthData>,
 

--- a/crates/ruma-client-api/src/uiaa.rs
+++ b/crates/ruma-client-api/src/uiaa.rs
@@ -729,3 +729,38 @@ impl OutgoingResponse for UiaaResponse {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use assert_matches2::assert_matches;
+    use serde;
+
+    #[test]
+    fn test_empty_uiaa_serialization() {
+        let input = "{}";
+        let result = serde_json::from_str::<super::AuthData>(input);
+        assert!(result.is_err());
+    }
+
+    #[derive(Debug, Default, serde::Serialize, serde::Deserialize)]
+    #[serde()]
+    struct Request {
+        /// Additional authentication information for the user-interactive authentication API.
+        #[serde(deserialize_with = "ruma_common::serde::or_empty")]
+        pub auth: Option<super::AuthData>,
+    }
+
+    #[test]
+    fn test_option_uiaa_serialization() {
+        let input = r#"{"auth": {}}"#;
+        let result = serde_json::from_str::<Request>(input).unwrap();
+        assert_matches!(result.auth, None);
+    }
+
+    #[test]
+    fn test_fail_uiaa_serialization() {
+        let input = r#"{"auth": "aaw"}"#;
+        let result = serde_json::from_str::<Request>(input);
+        assert!(result.is_err());
+    }
+}

--- a/crates/ruma-common/src/encryption.rs
+++ b/crates/ruma-common/src/encryption.rs
@@ -118,7 +118,7 @@ pub enum OneTimeKey {
 /// A [cross-signing] key.
 ///
 /// [cross-signing]: https://spec.matrix.org/latest/client-server-api/#cross-signing
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct CrossSigningKey {
     /// The ID of the user the key belongs to.

--- a/crates/ruma-common/src/identifiers/signatures.rs
+++ b/crates/ruma-common/src/identifiers/signatures.rs
@@ -27,7 +27,7 @@ pub type EntitySignatures<K> = BTreeMap<OwnedSigningKeyId<K>, String>;
 ///     "YbJva03ihSj5mPk+CHMJKUKlCXCPFXjXOK6VqBnN9nA2evksQcTGn6hwQfrgRHIDDXO2le49x7jnWJHMJrJoBQ";
 /// signatures.insert_signature(server_name, key_identifier, signature.into());
 /// ```
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
 #[serde(
     transparent,
     bound(serialize = "E: Serialize", deserialize = "E: serde::de::DeserializeOwned")

--- a/crates/ruma-common/src/serde.rs
+++ b/crates/ruma-common/src/serde.rs
@@ -69,6 +69,19 @@ pub fn is_true(b: &bool) -> bool {
     *b
 }
 
+/// Returns None if the serialization fails
+pub fn or_empty<'de, D: Deserializer<'de>, T: Deserialize<'de>>(
+        deserializer: D,
+    ) -> Result<Option<T>, D::Error> {
+        #[derive(serde::Deserialize)]
+        #[serde(untagged)]
+        enum OrEmpty<T> {
+            NotEmpty(T),
+            Empty {},
+        }
+        let res = <Option<OrEmpty<T>> as Deserialize<'de>>::deserialize(deserializer)?;
+        Ok(res.and_then(|res| if let OrEmpty::NotEmpty(a) = res { Some(a) } else { None }))
+    }
 /// Helper function for `serde_json::value::RawValue` deserialization.
 #[inline(never)]
 pub fn from_raw_json_value<'a, T, E>(val: &'a RawJsonValue) -> Result<T, E>


### PR DESCRIPTION
<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->
