### PR TITLE
better error reporting for ruma_common::serde::or_empty

### DIFF
--- a/crates/ruma-common/src/serde.rs
+++ b/crates/ruma-common/src/serde.rs
@@ -70,17 +70,26 @@ pub fn is_true(b: &bool) -> bool {
 }
 
 /// Returns None if the serialization fails
-pub fn or_empty<'de, D: Deserializer<'de>, T: Deserialize<'de>>(
+pub fn or_empty<'de, D: Deserializer<'de>, T: for <'a> Deserialize<'a>>(
         deserializer: D,
     ) -> Result<Option<T>, D::Error> {
-        #[derive(serde::Deserialize)]
-        #[serde(untagged)]
-        enum OrEmpty<T> {
-            NotEmpty(T),
-            Empty {},
+        let json = Box::<RawJsonValue>::deserialize(deserializer)?;
+
+        let res = serde_json::from_str::<Option<T>>(json.get()).map_err(de::Error::custom);
+
+        match res {
+            Ok(a) => Ok(a),
+            Err(e) => {
+                #[derive(Deserialize)]
+                #[serde(deny_unknown_fields)]
+                struct Empty {};
+                if let Ok(Empty {}) = serde_json::from_str(json.get()) {
+                    Ok(None)
+                } else {
+                    Err(e)
+                }
+            }
         }
-        let res = <Option<OrEmpty<T>> as Deserialize<'de>>::deserialize(deserializer)?;
-        Ok(res.and_then(|res| if let OrEmpty::NotEmpty(a) = res { Some(a) } else { None }))
     }
 /// Helper function for `serde_json::value::RawValue` deserialization.
 #[inline(never)]


### PR DESCRIPTION
the previous PR (#16) swallows any errors with the deserialization, resulting in "could not deserialize into any variant of untagged enum..."

this is a better solution that will preserve the original error message
