### PR TITLE
Check room_types in Filter::is_empty

### DIFF
--- a/crates/ruma-common/src/directory.rs
+++ b/crates/ruma-common/src/directory.rs
@@ -136,7 +136,7 @@ impl Filter {
 
     /// Returns `true` if the filter is empty.
     pub fn is_empty(&self) -> bool {
-        self.generic_search_term.is_none()
+        self.generic_search_term.is_none() && self.room_types.is_empty()
     }
 }
 


### PR DESCRIPTION
Fully fixes https://github.com/girlbossceo/conduwuit/issues/697 for federated rooms.